### PR TITLE
adding automated scanning of map urls provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 env/
 Gemfile.lock
 _site

--- a/README.md
+++ b/README.md
@@ -6,9 +6,56 @@ This repository contains static files and workflows to generate the HPC.social m
 
 ## How does it work?
 
-The form that is provided [on the site]() is fed into Google Sheets, and the workflow
-to [.github/workflows/update-map.yml](.github/workflows/update-map.yml) is able to
-parse the sheet for locations and then update the map!
+The form that is provided [on the site](https://hpc.social/projects/map/) is fed into Google 
+Sheets, and the workflow to [.github/workflows/update-map.yml](.github/workflows/update-map.yml) is able to
+parse the sheet for locations and then update the map! In addition to spot checks of the
+sheet, during the addition we have an automated workflow that checks any provided url for:
+
+ - spam
+ - phishing
+ - suspicious
+ - adult content
+ - malware
+ 
+And we keep a cache of scanned (and determined safe) URL entries in [scripts/scanned-urls.txt](scripts/scanned-urls.txt),
+the reason being that the free tier of the API only allows 5K calls per month, and we want to use those wisely!
+We use [this API](https://www.ipqualityscore.com/documentation/malicious-url-scanner-api/overview), and the token for
+scanning is provided in the GitHub repository action. Keep in mind if you run the update locally
+without a token, you will not be checking URLs and should do it manually. If any detection is made,
+the workflow is cancelled and the offending entry can then be removed from the sheet.
+Here is what an example response looks like:
+
+```console
+{
+    "message": "Success.",
+    "success": true,
+    "unsafe": false,
+    "domain": "github.com",
+    "ip_address": "140.82.114.4",
+    "server": "GitHub.com",
+    "content_type": "text/html; charset=utf-8",
+    "status_code": 200,
+    "page_size": 23542,
+    "domain_rank": 37,
+    "dns_valid": true,
+    "parking": false,
+    "spamming": false,
+    "malware": false,
+    "phishing": false,
+    "suspicious": false,
+    "adult": false,
+    "risk_score": 0,
+    "category": "Computers & internet",
+    "domain_age": {
+        "human": "15 years ago",
+        "timestamp": 1191954050,
+        "iso": "2007-10-09T14:20:50-04:00"
+    },
+    "request_id": "98VQ5x8beq"
+}
+```
+
+Very cool!
 
 ## Development
 

--- a/_data/group-locations.csv
+++ b/_data/group-locations.csv
@@ -5,6 +5,5 @@ address,lat,lng,name,url
 "zagreb, zagreb, croatia",45.84264135,15.962231476593626,University of Zagreb- University Computing Centre- Croatia,https://www.srce.hr/en/
 "lubbock, texas, united states",33.5635206,-101.879336,Texas Tech University High Performance Computing Center,https://www.depts.ttu.edu/hpcc
 "sheffield, south yorkshire, united kingdom",53.3806626,-1.4702278,Research and Innovation IT- IT Services- University of Sheffield,https://www.sheffield.ac.uk/it-services
-"urbana, il, usa",40.1117174,-88.207301,The National Center for Supercomputing Applications,https://ncsa.illinois.edu
-"sheffield, south yorkshire, united kingdom",53.3806626,-1.4702278,University of Sheffield - IT Services Research & Innovation team at the,https://github.com/rcgsheffield
+"urbana, illinois, united states",40.1117174,-88.207301,The National Center for Supercomputing Applications,https://ncsa.illinois.edu
 "sheffield, south yorkshire, united kingdom",53.3806626,-1.4702278,University of Sheffield - IT Services - Research & Innovation IT team,https://github.com/rcgsheffield

--- a/_data/locations.csv
+++ b/_data/locations.csv
@@ -24,5 +24,5 @@ address,lat,lng,count,name
 "albuquerque, new mexico, united states",35.0841034,-106.650985,1,
 "taunton, somerset, united kingdom",51.0147895,-3.1029086,1,
 "ottawa, ontario, canada",45.4208777,-75.6901106,1,FelixCLC
-"oakland, ca, usa",37.8044557,-122.271356,1,Glenn K. Lockwood
-"middletown, new york, united states",40.8397222,-73.8316667,1,Individual
+"oakland, california, united states",37.8044557,-122.271356,1,Glenn K. Lockwood
+"middletown, new york, united states",40.8397222,-73.8316667,1,

--- a/scripts/scanned-urls.txt
+++ b/scripts/scanned-urls.txt
@@ -1,0 +1,8 @@
+https://www.epcc.ed.ac.uk/
+https://www.nersc.gov/
+https://www.depts.ttu.edu/hpcc
+https://ncsa.illinois.edu
+https://www.sheffield.ac.uk/it-services
+https://www.srce.hr/en/
+https://github.com/rcgsheffield
+https://orcd.mit.edu/


### PR DESCRIPTION
This will partially address checking map input, for the URL. We have a token in the repository secrets for this API https://www.ipqualityscore.com/documentation/malicious-url-scanner-api/overview, and anytime a new URL comes in for a group, we scan it and make sure it isn't flagged for any bad category. We save a cache of the good URLs, and this is because if we don't the scanning will be redundant and we will likely go over our (fairly good) limit of 5K requests per month (and resets monthly).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>